### PR TITLE
run as root, because mkdir, apt install etc. require it

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,3 +1,4 @@
 - hosts: all
+  user: root
   roles:
     - haproxy-vip-docker


### PR DESCRIPTION
need to explicitly specify running as root, otherwise non-root users will receive an error